### PR TITLE
Clean up notes and title

### DIFF
--- a/Iron Banner Trials community favs
+++ b/Iron Banner Trials community favs
@@ -1,5 +1,8 @@
+title:Sharditkeepit Community S14 Iron Banner / Trials community favorites
+description:Originally found at https://www.reddit.com/r/sharditkeepit/comments/npwigw/communitysourced_season_of_the_splicer_breakdown/
+
 // Riiswalker
-//notes:Sharditkeepit Community (https://bit.ly/2R9OsyK): Sharditkeepit Community - PVE recommended roll
+//notes:Sharditkeepit Community - PVE recommended roll
 dimwishlist:item=108221785&perks=4090651448,791862061,3436462433,1546637391,684616255
 dimwishlist:item=108221785&perks=1047830412,791862061,3436462433,1546637391,684616255
 dimwishlist:item=108221785&perks=1482024992,791862061,3436462433,1546637391,684616255
@@ -219,9 +222,7 @@ dimwishlist:item=108221785&perks=1482024992,106909392,706527188,3523296417,75809
 
 
 // Riiswalker
-//notes:Sharditkeepit Community (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Hip-Fire Grip for PC and Slideways for Console
+//notes:sharditkeepit Community - PVP recommended roll - Hip-Fire Grip for MKB and Slideways for Controller
 dimwishlist:item=108221785&perks=1047830412,3142289711,706527188,591790007,684616255
 dimwishlist:item=108221785&perks=1332244541,3142289711,706527188,591790007,684616255
 dimwishlist:item=108221785&perks=1047830412,791862061,706527188,591790007,684616255
@@ -321,9 +322,7 @@ dimwishlist:item=108221785&perks=1332244541,791862061,2039302152,1546637391,2697
 
 
 // Archon's Thunder
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-Appended Mag (PC), Flared Magwell (Console)
+//notes: sharditkeepit Community - PVE recommended roll - Appended Mag (MKB), Flared Magwell (Controller)
 dimwishlist:item=1967303408&perks=839105230,106909392,2869569095,3425386926,384158423
 dimwishlist:item=1967303408&perks=1482024992,106909392,2869569095,3425386926,384158423
 dimwishlist:item=1967303408&perks=839105230,1087426260,2869569095,3425386926,384158423
@@ -423,9 +422,7 @@ dimwishlist:item=1967303408&perks=1482024992,3230963543,3436462433,2726471870,75
 
 
 // Archon's Thunder
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Hammer-Forged Rifling (PC), Fluted Barrel (Console), Accurized Rounds (PC), Steady Rounds (Console), Surplus (Console), Iron Grip (PC), Snapshot Sights (Console),  Range (PC), Stability (Console)
+//notes: sharditkeepit Community - PVP recommended roll - Hammer-Forged Rifling (MKB), Fluted Barrel (Controller), Accurized Rounds (MKB), Steady Rounds (Controller), Surplus (Controller), Iron Grip (MKB), Snapshot Sights (Controller),  Range (MKB), Stability (Controller)
 dimwishlist:item=1967303408&perks=839105230,3142289711,2846385770,11551321,384158423
 dimwishlist:item=1967303408&perks=1482024992,3142289711,2846385770,11551321,384158423
 dimwishlist:item=1967303408&perks=839105230,106909392,2846385770,11551321,384158423
@@ -717,7 +714,7 @@ dimwishlist:item=1967303408&perks=1482024992,3177308360,3436462433,3425386926,26
 
 
 // Occluded Finality
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community  - PVE recommended roll
+//notes: sharditkeepit Community  - PVE recommended roll
 dimwishlist:item=852551895&perks=1840239774,1087426260,3300816228,1546637391,186337601
 dimwishlist:item=852551895&perks=839105230,1087426260,3300816228,1546637391,186337601
 dimwishlist:item=852551895&perks=1840239774,2420895100,3300816228,1546637391,186337601
@@ -785,9 +782,7 @@ dimwishlist:item=852551895&perks=839105230,2420895100,3436462433,3523296417,7580
 
 
 // Occluded Finality
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Arrowhead Brake (PC), Corkscrew Rifling (Console), High-Caliber Rounds (PC), Flared Magwell (Console), No Distractions (PC), Mulligan (Console)
+//notes: sharditkeepit Community - PVP recommended roll - Arrowhead Brake (MKB), Corkscrew Rifling (Controller), High-Caliber Rounds (MKB), Flared Magwell (Controller), No Distractions (MKB), Mulligan (Controller)
 dimwishlist:item=852551895&perks=1840239774,1885400500,957782887,47981717,186337601
 dimwishlist:item=852551895&perks=839105230,1885400500,957782887,47981717,186337601
 dimwishlist:item=852551895&perks=4090651448,1885400500,957782887,47981717,186337601
@@ -1007,9 +1002,7 @@ dimwishlist:item=852551895&perks=4090651448,3230963543,3513791699,591790007,2357
 
 
 // Finite Impactor
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-Slideways (Console)
+//notes: sharditkeepit Community - PVE recommended roll - Slideways (Controller)
 dimwishlist:item=3813153080&perks=1926090092,1885400500,1570042021,2458213969,684616255
 dimwishlist:item=3813153080&perks=1926090095,1885400500,1570042021,2458213969,684616255
 dimwishlist:item=3813153080&perks=1926090094,1885400500,1570042021,2458213969,684616255
@@ -1229,9 +1222,7 @@ dimwishlist:item=3813153080&perks=1926090094,1087426260,2039302152,4049631843,75
 
 
 // Finite Impactor
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Eye of the Storm (Console)
+//notes: sharditkeepit Community - PVP recommended roll - Eye of the Storm (Controller)
 dimwishlist:item=3813153080&perks=1926090094,1561002382,2450788523,591790007,684616255
 dimwishlist:item=3813153080&perks=1926090095,1561002382,2450788523,591790007,684616255
 dimwishlist:item=3813153080&perks=1926090092,1561002382,2450788523,591790007,684616255
@@ -1307,9 +1298,7 @@ dimwishlist:item=3813153080&perks=1926090092,1885400500,1570042021,699525795,269
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-PC
+//notes: sharditkeepit Community - PVE recommended roll - MKB
 dimwishlist:item=3682803680&perks=3250034553,106909392,1570042021,1015611457,684616255
 dimwishlist:item=3682803680&perks=1482024992,106909392,1570042021,1015611457,684616255
 dimwishlist:item=3682803680&perks=4090651448,106909392,1570042021,1015611457,684616255
@@ -1457,9 +1446,7 @@ dimwishlist:item=3682803680&perks=4090651448,3230963543,2450788523,11612903,7580
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-Console
+//notes: sharditkeepit Community - PVE recommended roll - Controller
 dimwishlist:item=3682803680&perks=3661387068,106909392,1570042021,1015611457,384158423
 dimwishlist:item=3682803680&perks=1840239774,106909392,1570042021,1015611457,384158423
 dimwishlist:item=3682803680&perks=1392496348,106909392,1570042021,1015611457,384158423
@@ -1679,9 +1666,7 @@ dimwishlist:item=3682803680&perks=1392496348,3230963543,2946784966,11612903,7580
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-PC
+//notes: sharditkeepit Community - PVP recommended roll - MKB
 dimwishlist:item=3682803680&perks=3250034553,3142289711,1359896290,1015611457,684616255
 dimwishlist:item=3682803680&perks=1482024992,3142289711,1359896290,1015611457,684616255
 dimwishlist:item=3682803680&perks=3250034553,106909392,1359896290,1015611457,684616255
@@ -1733,9 +1718,7 @@ dimwishlist:item=3682803680&perks=1482024992,106909392,1570042021,1890422124,269
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Console
+//notes: sharditkeepit Community - PVP recommended roll - Controller
 dimwishlist:item=3682803680&perks=4090651448,3142289711,1359896290,1015611457,384158423
 dimwishlist:item=3682803680&perks=3250034553,3142289711,1359896290,1015611457,384158423
 dimwishlist:item=3682803680&perks=4090651448,106909392,1359896290,1015611457,384158423
@@ -1835,9 +1818,7 @@ dimwishlist:item=3682803680&perks=3250034553,106909392,1570042021,1890422124,269
 
 
 // Eye of Sol
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
- Smallbore (Console)
+//notes: sharditkeepit Community - PVE recommended roll - Smallbore (Controller)
 dimwishlist:item=3164743584&perks=1840239774,106909392,3436462433,1546637391,178753455
 dimwishlist:item=3164743584&perks=4090651448,106909392,3436462433,1546637391,178753455
 dimwishlist:item=3164743584&perks=1482024992,106909392,3436462433,1546637391,178753455
@@ -1889,7 +1870,7 @@ dimwishlist:item=3164743584&perks=1482024992,1087426260,2866798147,2213355989,75
 
 
 // Eye of Sol
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
+//notes: sharditkeepit Community - PVP recommended roll
 dimwishlist:item=3164743584&perks=1840239774,3142289711,588594999,957782887,684616255
 dimwishlist:item=3164743584&perks=4090651448,3142289711,588594999,957782887,684616255
 dimwishlist:item=3164743584&perks=839105230,3142289711,588594999,957782887,684616255
@@ -1986,6 +1967,3 @@ dimwishlist:item=3164743584&perks=839105230,3142289711,2866798147,47981717,23575
 dimwishlist:item=3164743584&perks=1840239774,106909392,2866798147,47981717,2357520979
 dimwishlist:item=3164743584&perks=4090651448,106909392,2866798147,47981717,2357520979
 dimwishlist:item=3164743584&perks=839105230,106909392,2866798147,47981717,2357520979
-
-
-

--- a/Override Community Favs
+++ b/Override Community Favs
@@ -1,5 +1,8 @@
+title:Sharditkeepit Community S14 Override community favorites
+description:Originally found at https://www.reddit.com/r/sharditkeepit/comments/nhaq1m/filling_the_void_of_upandapaxxy_the_experimental/
+
 // Chroma Rush
-//notes:community (???  ???): PVE - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVE - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1119734784&perks=1482024992,106909392,1820235745,3425386926
 dimwishlist:item=1119734784&perks=839105230,106909392,1820235745,3425386926
 dimwishlist:item=1119734784&perks=1482024992,1087426260,1820235745,3425386926
@@ -36,8 +39,9 @@ dimwishlist:item=1119734784&perks=1482024992,1087426260,1570042021,1015611457
 dimwishlist:item=1119734784&perks=839105230,1087426260,1570042021,1015611457
 dimwishlist:item=1119734784&perks=1482024992,3142289711,1570042021,1015611457
 dimwishlist:item=1119734784&perks=839105230,3142289711,1570042021,1015611457
+
 // Chroma Rush
-//notes:community (???  ???): PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1119734784&perks=1482024992,3142289711,1359896290,1015611457
 dimwishlist:item=1119734784&perks=3250034553,3142289711,1359896290,1015611457
 dimwishlist:item=1119734784&perks=839105230,3142289711,1359896290,1015611457
@@ -74,8 +78,9 @@ dimwishlist:item=1119734784&perks=839105230,3142289711,1570042021,3425386926
 dimwishlist:item=1119734784&perks=1482024992,106909392,1570042021,3425386926
 dimwishlist:item=1119734784&perks=3250034553,106909392,1570042021,3425386926
 dimwishlist:item=1119734784&perks=839105230,106909392,1570042021,3425386926
+
 // Ignition Code
-//notes:community (???  ???): PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=304659313&perks=3525010810,3301904089,2010801679,1546637391
 dimwishlist:item=304659313&perks=981914802,3301904089,2010801679,1546637391
 dimwishlist:item=304659313&perks=3525010810,3032599245,2010801679,1546637391
@@ -100,8 +105,9 @@ dimwishlist:item=304659313&perks=3525010810,3301904089,3161816588,3523296417
 dimwishlist:item=304659313&perks=981914802,3301904089,3161816588,3523296417
 dimwishlist:item=304659313&perks=3525010810,3032599245,3161816588,3523296417
 dimwishlist:item=304659313&perks=981914802,3032599245,3161816588,3523296417
+
 // Ignition Code
-//notes:community (???  ???): PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=304659313&perks=3525010810,3301904089,3161816588,1546637391
 dimwishlist:item=304659313&perks=981914802,3301904089,3161816588,1546637391
 dimwishlist:item=304659313&perks=3525010810,409831596,3161816588,1546637391
@@ -126,8 +132,9 @@ dimwishlist:item=304659313&perks=3525010810,3301904089,706527188,2726471870
 dimwishlist:item=304659313&perks=981914802,3301904089,706527188,2726471870
 dimwishlist:item=304659313&perks=3525010810,409831596,706527188,2726471870
 dimwishlist:item=304659313&perks=981914802,409831596,706527188,2726471870
+
 // Farewell
-//notes:community (???  ???): PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=541188001&perks=1482024992,106909392,2117683199,4104185692
 dimwishlist:item=541188001&perks=4090651448,106909392,2117683199,4104185692
 dimwishlist:item=541188001&perks=1482024992,3142289711,2117683199,4104185692
@@ -192,8 +199,9 @@ dimwishlist:item=541188001&perks=1482024992,1087426260,4267945040,1015611457
 dimwishlist:item=541188001&perks=4090651448,1087426260,4267945040,1015611457
 dimwishlist:item=541188001&perks=1482024992,3230963543,4267945040,1015611457
 dimwishlist:item=541188001&perks=4090651448,3230963543,4267945040,1015611457
+
 // Farewell
-//notes:community (???  ???): PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=541188001&perks=1482024992,3142289711,2846385770,1015611457
 dimwishlist:item=541188001&perks=3250034553,3142289711,2846385770,1015611457
 dimwishlist:item=541188001&perks=1482024992,106909392,2846385770,1015611457
@@ -230,8 +238,9 @@ dimwishlist:item=541188001&perks=1482024992,3142289711,4267945040,2726471870
 dimwishlist:item=541188001&perks=3250034553,3142289711,4267945040,2726471870
 dimwishlist:item=541188001&perks=1482024992,106909392,4267945040,2726471870
 dimwishlist:item=541188001&perks=3250034553,106909392,4267945040,2726471870
+
 // Gridskipper
-//notes:community (???  ???): PvE Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PvE Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1621558458&perks=839105230,1885400500,1570042021,4104185692
 dimwishlist:item=1621558458&perks=1482024992,1885400500,1570042021,4104185692
 dimwishlist:item=1621558458&perks=839105230,1087426260,1570042021,4104185692
@@ -256,8 +265,9 @@ dimwishlist:item=1621558458&perks=839105230,1885400500,2450788523,2726471870
 dimwishlist:item=1621558458&perks=1482024992,1885400500,2450788523,2726471870
 dimwishlist:item=1621558458&perks=839105230,1087426260,2450788523,2726471870
 dimwishlist:item=1621558458&perks=1482024992,1087426260,2450788523,2726471870
+
 // Gridskipper
-//notes:community (???  ???): PvP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PvP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1621558458&perks=839105230,1885400500,1570042021,957782887
 dimwishlist:item=1621558458&perks=1482024992,1885400500,1570042021,957782887
 dimwishlist:item=1621558458&perks=839105230,1561002382,1570042021,957782887

--- a/Season 14 Community Favs
+++ b/Season 14 Community Favs
@@ -1,5 +1,8 @@
+title:Sharditkeepit Community S14 community favorites for Override, Iron Banner, and Trials
+description:Originally found at https://www.reddit.com/r/sharditkeepit/comments/nhaq1m/filling_the_void_of_upandapaxxy_the_experimental/ and https://www.reddit.com/r/sharditkeepit/comments/npwigw/communitysourced_season_of_the_splicer_breakdown/
+
 // Chroma Rush
-//notes:community (https://bit.ly/2SKMvcz): PVE - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVE - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1119734784&perks=1482024992,106909392,1820235745,3425386926
 dimwishlist:item=1119734784&perks=839105230,106909392,1820235745,3425386926
 dimwishlist:item=1119734784&perks=1482024992,1087426260,1820235745,3425386926
@@ -36,8 +39,9 @@ dimwishlist:item=1119734784&perks=1482024992,1087426260,1570042021,1015611457
 dimwishlist:item=1119734784&perks=839105230,1087426260,1570042021,1015611457
 dimwishlist:item=1119734784&perks=1482024992,3142289711,1570042021,1015611457
 dimwishlist:item=1119734784&perks=839105230,3142289711,1570042021,1015611457
+
 // Chroma Rush
-//notes:community (https://bit.ly/2SKMvcz): PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1119734784&perks=1482024992,3142289711,1359896290,1015611457
 dimwishlist:item=1119734784&perks=3250034553,3142289711,1359896290,1015611457
 dimwishlist:item=1119734784&perks=839105230,3142289711,1359896290,1015611457
@@ -74,8 +78,9 @@ dimwishlist:item=1119734784&perks=839105230,3142289711,1570042021,3425386926
 dimwishlist:item=1119734784&perks=1482024992,106909392,1570042021,3425386926
 dimwishlist:item=1119734784&perks=3250034553,106909392,1570042021,3425386926
 dimwishlist:item=1119734784&perks=839105230,106909392,1570042021,3425386926
+
 // Ignition Code
-//notes:community (https://bit.ly/2SKMvcz): PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=304659313&perks=3525010810,3301904089,2010801679,1546637391
 dimwishlist:item=304659313&perks=981914802,3301904089,2010801679,1546637391
 dimwishlist:item=304659313&perks=3525010810,3032599245,2010801679,1546637391
@@ -100,8 +105,9 @@ dimwishlist:item=304659313&perks=3525010810,3301904089,3161816588,3523296417
 dimwishlist:item=304659313&perks=981914802,3301904089,3161816588,3523296417
 dimwishlist:item=304659313&perks=3525010810,3032599245,3161816588,3523296417
 dimwishlist:item=304659313&perks=981914802,3032599245,3161816588,3523296417
+
 // Ignition Code
-//notes:community (https://bit.ly/2SKMvcz): PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=304659313&perks=3525010810,3301904089,3161816588,1546637391
 dimwishlist:item=304659313&perks=981914802,3301904089,3161816588,1546637391
 dimwishlist:item=304659313&perks=3525010810,409831596,3161816588,1546637391
@@ -126,8 +132,9 @@ dimwishlist:item=304659313&perks=3525010810,3301904089,706527188,2726471870
 dimwishlist:item=304659313&perks=981914802,3301904089,706527188,2726471870
 dimwishlist:item=304659313&perks=3525010810,409831596,706527188,2726471870
 dimwishlist:item=304659313&perks=981914802,409831596,706527188,2726471870
+
 // Farewell
-//notes:community (https://bit.ly/2SKMvcz): PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVE Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=541188001&perks=1482024992,106909392,2117683199,4104185692
 dimwishlist:item=541188001&perks=4090651448,106909392,2117683199,4104185692
 dimwishlist:item=541188001&perks=1482024992,3142289711,2117683199,4104185692
@@ -192,8 +199,9 @@ dimwishlist:item=541188001&perks=1482024992,1087426260,4267945040,1015611457
 dimwishlist:item=541188001&perks=4090651448,1087426260,4267945040,1015611457
 dimwishlist:item=541188001&perks=1482024992,3230963543,4267945040,1015611457
 dimwishlist:item=541188001&perks=4090651448,3230963543,4267945040,1015611457
+
 // Farewell
-//notes:community (https://bit.ly/2SKMvcz): PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PVP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=541188001&perks=1482024992,3142289711,2846385770,1015611457
 dimwishlist:item=541188001&perks=3250034553,3142289711,2846385770,1015611457
 dimwishlist:item=541188001&perks=1482024992,106909392,2846385770,1015611457
@@ -230,8 +238,9 @@ dimwishlist:item=541188001&perks=1482024992,3142289711,4267945040,2726471870
 dimwishlist:item=541188001&perks=3250034553,3142289711,4267945040,2726471870
 dimwishlist:item=541188001&perks=1482024992,106909392,4267945040,2726471870
 dimwishlist:item=541188001&perks=3250034553,106909392,4267945040,2726471870
+
 // Gridskipper
-//notes:community (https://bit.ly/2SKMvcz): PvE Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PvE Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1621558458&perks=839105230,1885400500,1570042021,4104185692
 dimwishlist:item=1621558458&perks=1482024992,1885400500,1570042021,4104185692
 dimwishlist:item=1621558458&perks=839105230,1087426260,1570042021,4104185692
@@ -256,8 +265,9 @@ dimwishlist:item=1621558458&perks=839105230,1885400500,2450788523,2726471870
 dimwishlist:item=1621558458&perks=1482024992,1885400500,2450788523,2726471870
 dimwishlist:item=1621558458&perks=839105230,1087426260,2450788523,2726471870
 dimwishlist:item=1621558458&perks=1482024992,1087426260,2450788523,2726471870
+
 // Gridskipper
-//notes:community (https://bit.ly/2SKMvcz): PvP Perks - Experimental Community-Sourced Weapons Preferences Survey
+//notes:Sharditkeepit Community: PvP Perks - Experimental Community-Sourced Weapons Preferences Survey
 dimwishlist:item=1621558458&perks=839105230,1885400500,1570042021,957782887
 dimwishlist:item=1621558458&perks=1482024992,1885400500,1570042021,957782887
 dimwishlist:item=1621558458&perks=839105230,1561002382,1570042021,957782887
@@ -296,7 +306,7 @@ dimwishlist:item=1621558458&perks=839105230,1561002382,2450788523,2458213969
 dimwishlist:item=1621558458&perks=1482024992,1561002382,2450788523,2458213969
 
 // Riiswalker
-//notes:Sharditkeepit Community (https://bit.ly/2R9OsyK): Sharditkeepit Community - PVE recommended roll
+//notes:Sharditkeepit Community - PVE recommended roll
 dimwishlist:item=108221785&perks=4090651448,791862061,3436462433,1546637391,684616255
 dimwishlist:item=108221785&perks=1047830412,791862061,3436462433,1546637391,684616255
 dimwishlist:item=108221785&perks=1482024992,791862061,3436462433,1546637391,684616255
@@ -516,9 +526,7 @@ dimwishlist:item=108221785&perks=1482024992,106909392,706527188,3523296417,75809
 
 
 // Riiswalker
-//notes:Sharditkeepit Community (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Hip-Fire Grip for PC and Slideways for Console
+//notes:sharditkeepit Community - PVP recommended roll - Hip-Fire Grip for MKB and Slideways for Controller
 dimwishlist:item=108221785&perks=1047830412,3142289711,706527188,591790007,684616255
 dimwishlist:item=108221785&perks=1332244541,3142289711,706527188,591790007,684616255
 dimwishlist:item=108221785&perks=1047830412,791862061,706527188,591790007,684616255
@@ -618,9 +626,7 @@ dimwishlist:item=108221785&perks=1332244541,791862061,2039302152,1546637391,2697
 
 
 // Archon's Thunder
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-Appended Mag (PC), Flared Magwell (Console)
+//notes: sharditkeepit Community - PVE recommended roll - Appended Mag (MKB), Flared Magwell (Controller)
 dimwishlist:item=1967303408&perks=839105230,106909392,2869569095,3425386926,384158423
 dimwishlist:item=1967303408&perks=1482024992,106909392,2869569095,3425386926,384158423
 dimwishlist:item=1967303408&perks=839105230,1087426260,2869569095,3425386926,384158423
@@ -720,9 +726,7 @@ dimwishlist:item=1967303408&perks=1482024992,3230963543,3436462433,2726471870,75
 
 
 // Archon's Thunder
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Hammer-Forged Rifling (PC), Fluted Barrel (Console), Accurized Rounds (PC), Steady Rounds (Console), Surplus (Console), Iron Grip (PC), Snapshot Sights (Console),  Range (PC), Stability (Console)
+//notes: sharditkeepit Community - PVP recommended roll - Hammer-Forged Rifling (MKB), Fluted Barrel (Controller), Accurized Rounds (MKB), Steady Rounds (Controller), Surplus (Controller), Iron Grip (MKB), Snapshot Sights (Controller),  Range (MKB), Stability (Controller)
 dimwishlist:item=1967303408&perks=839105230,3142289711,2846385770,11551321,384158423
 dimwishlist:item=1967303408&perks=1482024992,3142289711,2846385770,11551321,384158423
 dimwishlist:item=1967303408&perks=839105230,106909392,2846385770,11551321,384158423
@@ -1014,7 +1018,7 @@ dimwishlist:item=1967303408&perks=1482024992,3177308360,3436462433,3425386926,26
 
 
 // Occluded Finality
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community  - PVE recommended roll
+//notes: sharditkeepit Community  - PVE recommended roll
 dimwishlist:item=852551895&perks=1840239774,1087426260,3300816228,1546637391,186337601
 dimwishlist:item=852551895&perks=839105230,1087426260,3300816228,1546637391,186337601
 dimwishlist:item=852551895&perks=1840239774,2420895100,3300816228,1546637391,186337601
@@ -1082,9 +1086,7 @@ dimwishlist:item=852551895&perks=839105230,2420895100,3436462433,3523296417,7580
 
 
 // Occluded Finality
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Arrowhead Brake (PC), Corkscrew Rifling (Console), High-Caliber Rounds (PC), Flared Magwell (Console), No Distractions (PC), Mulligan (Console)
+//notes: sharditkeepit Community - PVP recommended roll - Arrowhead Brake (MKB), Corkscrew Rifling (Controller), High-Caliber Rounds (MKB), Flared Magwell (Controller), No Distractions (MKB), Mulligan (Controller)
 dimwishlist:item=852551895&perks=1840239774,1885400500,957782887,47981717,186337601
 dimwishlist:item=852551895&perks=839105230,1885400500,957782887,47981717,186337601
 dimwishlist:item=852551895&perks=4090651448,1885400500,957782887,47981717,186337601
@@ -1304,9 +1306,7 @@ dimwishlist:item=852551895&perks=4090651448,3230963543,3513791699,591790007,2357
 
 
 // Finite Impactor
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-Slideways (Console)
+//notes: sharditkeepit Community - PVE recommended roll - Slideways (Controller)
 dimwishlist:item=3813153080&perks=1926090092,1885400500,1570042021,2458213969,684616255
 dimwishlist:item=3813153080&perks=1926090095,1885400500,1570042021,2458213969,684616255
 dimwishlist:item=3813153080&perks=1926090094,1885400500,1570042021,2458213969,684616255
@@ -1526,9 +1526,7 @@ dimwishlist:item=3813153080&perks=1926090094,1087426260,2039302152,4049631843,75
 
 
 // Finite Impactor
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Eye of the Storm (Console)
+//notes: sharditkeepit Community - PVP recommended roll - Eye of the Storm (Controller)
 dimwishlist:item=3813153080&perks=1926090094,1561002382,2450788523,591790007,684616255
 dimwishlist:item=3813153080&perks=1926090095,1561002382,2450788523,591790007,684616255
 dimwishlist:item=3813153080&perks=1926090092,1561002382,2450788523,591790007,684616255
@@ -1604,9 +1602,7 @@ dimwishlist:item=3813153080&perks=1926090092,1885400500,1570042021,699525795,269
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-PC
+//notes: sharditkeepit Community - PVE recommended roll - MKB
 dimwishlist:item=3682803680&perks=3250034553,106909392,1570042021,1015611457,684616255
 dimwishlist:item=3682803680&perks=1482024992,106909392,1570042021,1015611457,684616255
 dimwishlist:item=3682803680&perks=4090651448,106909392,1570042021,1015611457,684616255
@@ -1754,9 +1750,7 @@ dimwishlist:item=3682803680&perks=4090651448,3230963543,2450788523,11612903,7580
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
-Console
+//notes: sharditkeepit Community - PVE recommended roll - Controller
 dimwishlist:item=3682803680&perks=3661387068,106909392,1570042021,1015611457,384158423
 dimwishlist:item=3682803680&perks=1840239774,106909392,1570042021,1015611457,384158423
 dimwishlist:item=3682803680&perks=1392496348,106909392,1570042021,1015611457,384158423
@@ -1976,9 +1970,7 @@ dimwishlist:item=3682803680&perks=1392496348,3230963543,2946784966,11612903,7580
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-PC
+//notes: sharditkeepit Community - PVP recommended roll - MKB
 dimwishlist:item=3682803680&perks=3250034553,3142289711,1359896290,1015611457,684616255
 dimwishlist:item=3682803680&perks=1482024992,3142289711,1359896290,1015611457,684616255
 dimwishlist:item=3682803680&perks=3250034553,106909392,1359896290,1015611457,684616255
@@ -2030,9 +2022,7 @@ dimwishlist:item=3682803680&perks=1482024992,106909392,1570042021,1890422124,269
 
 
 // Shayura's Wrath
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
-
-Console
+//notes: sharditkeepit Community - PVP recommended roll - Controller
 dimwishlist:item=3682803680&perks=4090651448,3142289711,1359896290,1015611457,384158423
 dimwishlist:item=3682803680&perks=3250034553,3142289711,1359896290,1015611457,384158423
 dimwishlist:item=3682803680&perks=4090651448,106909392,1359896290,1015611457,384158423
@@ -2132,9 +2122,7 @@ dimwishlist:item=3682803680&perks=3250034553,106909392,1570042021,1890422124,269
 
 
 // Eye of Sol
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVE recommended roll
-
- Smallbore (Console)
+//notes: sharditkeepit Community - PVE recommended roll - Smallbore (Controller)
 dimwishlist:item=3164743584&perks=1840239774,106909392,3436462433,1546637391,178753455
 dimwishlist:item=3164743584&perks=4090651448,106909392,3436462433,1546637391,178753455
 dimwishlist:item=3164743584&perks=1482024992,106909392,3436462433,1546637391,178753455
@@ -2186,7 +2174,7 @@ dimwishlist:item=3164743584&perks=1482024992,1087426260,2866798147,2213355989,75
 
 
 // Eye of Sol
-//notes: (https://bit.ly/2R9OsyK): sharditkeepit Community - PVP recommended roll
+//notes: sharditkeepit Community - PVP recommended roll
 dimwishlist:item=3164743584&perks=1840239774,3142289711,588594999,957782887,684616255
 dimwishlist:item=3164743584&perks=4090651448,3142289711,588594999,957782887,684616255
 dimwishlist:item=3164743584&perks=839105230,3142289711,588594999,957782887,684616255
@@ -2283,7 +2271,3 @@ dimwishlist:item=3164743584&perks=839105230,3142289711,2866798147,47981717,23575
 dimwishlist:item=3164743584&perks=1840239774,106909392,2866798147,47981717,2357520979
 dimwishlist:item=3164743584&perks=4090651448,106909392,2866798147,47981717,2357520979
 dimwishlist:item=3164743584&perks=839105230,106909392,2866798147,47981717,2357520979
-
-
-
-


### PR DESCRIPTION
A gap between block notes and the list of items will effectively erase the notes, so I moved a few around.

I added a title + description to the notes (and linked to the reddit posts, rather than the bit.ly shortcut) and SIKI attribution to the block notes.

I also changed `Console` to `Controller` and `PC` to `MKB`, since I'm greedy and that's how the voltrons generally refer to them.